### PR TITLE
Add missing the map file example

### DIFF
--- a/missing-map/README.md
+++ b/missing-map/README.md
@@ -1,0 +1,1 @@
+This is a simple test for when a file claims to have a source map URL using the following syntax `//# sourceMappingURL=bundle.js.map` but that file can't be found by DevTools.

--- a/missing-map/bundle.js
+++ b/missing-map/bundle.js
@@ -1,0 +1,2 @@
+console.log('looking for bundle.js.map');
+//# sourceMappingURL=bundle.js.map

--- a/missing-map/index.html
+++ b/missing-map/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Test missing .map file</title>
+  </head>
+  <script src="bundle.js"></script>
+  <body>
+    <div>Test when a source map file is missing.</div>
+    <div>You should see an error in the console</div>
+  </body>
+</html>


### PR DESCRIPTION
Adds an example that is missing the `.map` file so you can easily see the output in the console.

<img width="428" alt="screen shot 2017-08-10 at 10 49 50 am" src="https://user-images.githubusercontent.com/2134/29186233-a7a82f4a-7dc0-11e7-96ad-d8e4a71f934d.png">
